### PR TITLE
remove card from booking-renter-index.scss

### DIFF
--- a/app/assets/stylesheets/components/_card_booking_renter_index.scss
+++ b/app/assets/stylesheets/components/_card_booking_renter_index.scss
@@ -1,8 +1,3 @@
-.cards {
-  display: block;
-
-}
-
 .card-product-renter {
   overflow: hidden;
   height: auto;


### PR DESCRIPTION
I removed .card {display: block} from booking-renter-index.scss to not impact homepage 